### PR TITLE
Add `autoStart` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const Uploader = () => {
 ### `useTus` hooks
 
 ```js
-const { upload, setUpload, isSuccess, error, remove } = useTus({ cacheKey, autoAbort });
+const { upload, setUpload, isSuccess, error, remove } = useTus({ cacheKey, autoAbort, autoStart });
 ```
 
 `useTus` is a hooks to get or create an `Upload` of tus.
@@ -103,6 +103,9 @@ const { upload, setUpload, isSuccess, error, remove } = useTus({ cacheKey, autoA
 
 - `autoAbort` (type: `boolean | undefined`) (default: true)
   - Whether or not to automatically abort uploads when useTus hooks is unmounted.
+
+- `autoStart` (type: `boolean | undefined`) (default: false)
+  - Whether or not to start upload the file after `setUpload` function.
 
 ### Returns
 - `upload` (type: `tus.Upload | undefined`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-tus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React hooks for resumable file uploads using tus-js-client",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/useTus/index.ts
+++ b/src/useTus/index.ts
@@ -1,2 +1,2 @@
 export { useTus } from './useTus';
-export type { UseTusResult, UseTusOptions } from './useTus';
+export type { UseTusResult, UseTusOptions } from './types';

--- a/src/useTus/types.ts
+++ b/src/useTus/types.ts
@@ -1,0 +1,15 @@
+import type { Upload } from 'tus-js-client';
+
+export type UseTusOptions = {
+  cacheKey?: string;
+  autoAbort?: boolean;
+  autoStart?: boolean;
+};
+export type UseTusResult = {
+  upload?: Upload;
+  setUpload: (file: Upload['file'], options?: Upload['options']) => void;
+  remove: () => void;
+  isSuccess: boolean;
+  error?: Error;
+};
+export type UseTusState = Pick<UseTusResult, 'upload' | 'isSuccess' | 'error'>;

--- a/src/useTus/utils.ts
+++ b/src/useTus/utils.ts
@@ -1,0 +1,72 @@
+import { SetStateAction } from 'react';
+import type { Upload } from 'tus-js-client';
+import {
+  errorUpload,
+  successUpload,
+  TusClientActions,
+} from '../core/tucClientActions';
+import { UseTusOptions, UseTusState } from './types';
+
+type Handlers = Pick<Upload['options'], 'onError' | 'onSuccess'>;
+type CreateHandlerArgs = {
+  handlers: Handlers;
+  dispatch: (value: TusClientActions) => void;
+  internalDispatch: (value: SetStateAction<UseTusState>) => void;
+  cacheKey: UseTusOptions['cacheKey'];
+};
+
+export const createHandler = ({
+  handlers,
+  dispatch,
+  internalDispatch,
+  cacheKey,
+}: CreateHandlerArgs): Handlers => {
+  const onSuccess = () => {
+    if (cacheKey) {
+      dispatch(successUpload(cacheKey));
+    }
+
+    if (!cacheKey) {
+      internalDispatch((internalTusState) => ({
+        ...internalTusState,
+        isSuccess: true,
+      }));
+    }
+
+    if (handlers.onSuccess) {
+      handlers.onSuccess();
+    }
+  };
+
+  const onError = (err: Error) => {
+    if (cacheKey) {
+      dispatch(errorUpload(cacheKey, err));
+    }
+
+    if (!cacheKey) {
+      internalDispatch((internalTusState) => ({
+        ...internalTusState,
+        error: err,
+      }));
+    }
+
+    if (handlers.onError) {
+      handlers.onError(err);
+    }
+  };
+
+  return {
+    onSuccess,
+    onError,
+  };
+};
+
+export const startOrResumeUpload = (upload: Upload): void => {
+  upload.findPreviousUploads().then((previousUploads) => {
+    if (previousUploads.length) {
+      upload.resumeFromPreviousUpload(previousUploads[0]);
+    }
+
+    upload.start();
+  });
+};


### PR DESCRIPTION
## Add `autoStart option for `useTus` hooks
Until now, when you wanted to upload a file, you had to use `upload`, the return value of useTus.

However, this has the problem that you have to wait for the life cycle of react.

With this option, you can start uploading immediately without waiting for the react lifecycle.

