### PR TITLE
Fix to abort uploading before remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-tus",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "React hooks for resumable file uploads using tus-js-client",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/__stories__/Basic.stories.tsx
+++ b/src/__stories__/Basic.stories.tsx
@@ -96,13 +96,13 @@ const Uploader = () => {
             title="Resume"
             styleColor="primary"
             onClick={handleOnStart}
-            disabled={!isAborted}
+            disabled={isSuccess || !isAborted}
           />
           <BasicButton
             title="Abort"
             styleColor="error"
             onClick={handleOnAbort}
-            disabled={!upload || isAborted}
+            disabled={isSuccess || !upload || isAborted}
           />
         </div>
         {upload && !isAborted && (

--- a/src/__stories__/CacheKey.stories.tsx
+++ b/src/__stories__/CacheKey.stories.tsx
@@ -115,13 +115,13 @@ const Uploader = () => {
             title="Resume"
             styleColor="primary"
             onClick={handleOnStart}
-            disabled={!isAborted}
+            disabled={isSuccess || !isAborted}
           />
           <BasicButton
             title="Abort"
             styleColor="error"
             onClick={handleOnAbort}
-            disabled={!upload || isAborted}
+            disabled={isSuccess || !upload || isAborted}
           />
         </div>
         {upload && !isAborted && (

--- a/src/useTus/useTus.ts
+++ b/src/useTus/useTus.ts
@@ -80,29 +80,33 @@ export const useTus = (useTusOptions?: UseTusOptions): UseTusResult => {
     [tusClientDispatch, cacheKey, tus, autoStart]
   );
 
+  const targetTusState = useMemo(
+    () => (cacheKey ? tusClientState.uploads[cacheKey] : internalTusState),
+    [cacheKey, tusClientState, internalTusState]
+  );
+
   const remove = useCallback(() => {
+    targetTusState?.upload?.abort();
+
     if (!cacheKey) {
       setInternalTusState(initialUseTusState);
       return;
     }
 
     tusClientDispatch(removeUploadInstance(cacheKey));
-  }, [tusClientDispatch, cacheKey]);
+  }, [targetTusState, tusClientDispatch, cacheKey]);
 
-  const tusResult: UseTusResult = useMemo(() => {
-    const targetTusState = cacheKey
-      ? tusClientState.uploads[cacheKey]
-      : internalTusState;
-
-    return {
+  const tusResult: UseTusResult = useMemo(
+    () => ({
       upload: targetTusState?.upload,
       isSuccess: targetTusState?.isSuccess ?? false,
       error: targetTusState?.error,
       isAborted: targetTusState?.isAborted ?? false,
       setUpload,
       remove,
-    };
-  }, [cacheKey, tusClientState, setUpload, remove, internalTusState]);
+    }),
+    [targetTusState, setUpload, remove]
+  );
 
   // For autoAbort option
   useEffect(() => {


### PR DESCRIPTION
## Overview
- Change to abort uploading before remove
  - `remove` function is return value of `useTus` hooks has a bug that was not abort uploading.
  -  This is PR will fix the bug.
- Update storybook's UI