### PR TITLE
Update defaultOptions props to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ const { upload, setUpload, isSuccess, isAborted, error, remove } = useTus({ cach
 - `canStoreURLs` (type: `boolean | undefined`)
   - A boolean indicating whether the current environment allows storing URLs enabling the corresponding upload to be resumed. [detail](https://github.com/tus/tus-js-client/blob/master/docs/api.md#tuscanstoreurls)
 
-- `defaultOptions` (type: `tus.DefaltOptions | undefined`)
+- `defaultOptions` (type: `(file: tus.Upload['file']) => tus.DefaltOptions | undefined`)
   - An object containing the default options used when creating a new upload. [detail](https://github.com/tus/tus-js-client/blob/master/docs/api.md#tusdefaultoptions)
 
 ## Examples
@@ -272,11 +272,21 @@ const Uploader = () => {
 You can specify default options in the `defaultOptions` props of the `TusClientProvider`.
 
 ```tsx
-import { useTus, TusClientProvider } from 'use-tus'
+import { useTus, DefaultOptions, TusClientProvider } from 'use-tus'
 
-const defaultOptions = {
-  endpoint: 'https://tusd.tusdemo.net/files/',
-}
+const defaultOptions: DefaultOptions = (contents) => {
+  const file = contents instanceof File ? contents : undefined;
+
+  return {
+    endpoint: 'https://tusd.tusdemo.net/files/',
+    metadata: file
+      ? {
+          filename: file.name,
+          filetype: file.type,
+        }
+      : undefined,
+  };
+};
 
 const App = () => (
   <TusClientProvider defaultOptions={defaultOptions}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-tus",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "React hooks for resumable file uploads using tus-js-client",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/TusClientProvider/TusController.tsx
+++ b/src/TusClientProvider/TusController.tsx
@@ -2,13 +2,13 @@ import { FC, useEffect } from 'react';
 import { ERROR_MESSAGES } from '../core/constants';
 import { updateTusHandlerOptions } from '../core/tucClientActions';
 import { useTusClientDispatch, useTusClientState } from '../core/contexts';
-import { TusConfigs } from '../core/tusHandler';
+import { initialDefaultOptions, TusConfigs } from '../core/tusHandler';
 
 export type TusControllerProps = Readonly<TusConfigs>;
 
 export const TusController: FC<TusControllerProps> = ({
   canStoreURLs,
-  defaultOptions,
+  defaultOptions = initialDefaultOptions,
   children,
 }) => {
   const { tusHandler } = useTusClientState();

--- a/src/__stories__/CacheKey.stories.tsx
+++ b/src/__stories__/CacheKey.stories.tsx
@@ -6,7 +6,7 @@ import { useTus, TusClientProvider } from '../index';
 import { BasicButton } from './components/BasicButton';
 import { LoadingCircle } from './components/LoadingCircle';
 import { UploadIcon } from './components/UploadIcon';
-import { defaultOptions } from './constants';
+import { TUS_DEMO_ENDPOINT } from './constants';
 
 export default {
   title: 'useTus',
@@ -56,7 +56,7 @@ const Uploader = () => {
       }
 
       setUpload(file, {
-        ...defaultOptions,
+        endpoint: TUS_DEMO_ENDPOINT,
         chunkSize: file.size / 10,
         metadata: {
           filename: file.name,
@@ -92,7 +92,7 @@ const Uploader = () => {
         <div className="mt-8">
           <UploadIcon />
         </div>
-        <div className="mt-8 flex justify-center items-center flex-col text-sm text-gray-700">
+        <div className="flex flex-col items-center justify-center mt-8 text-sm text-gray-700">
           <p>
             In this demo, you can upload to the demo-only server provided by tus
             official.

--- a/src/__stories__/DefaultOptions.stories.tsx
+++ b/src/__stories__/DefaultOptions.stories.tsx
@@ -18,10 +18,12 @@ const defaultOptions: DefaultOptions = (contents) => {
   return {
     endpoint: TUS_DEMO_ENDPOINT,
     chunkSize: file?.size ? file.size / 10 : undefined,
-    metadata: {
-      filename: file?.name || '',
-      filetype: file?.type || '',
-    },
+    metadata: file
+      ? {
+          filename: file.name,
+          filetype: file.type,
+        }
+      : undefined,
   };
 };
 

--- a/src/__stories__/DefaultOptions.stories.tsx
+++ b/src/__stories__/DefaultOptions.stories.tsx
@@ -2,18 +2,31 @@ import { Meta } from '@storybook/react';
 import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
 import { ProgressBar } from './components/ProgressBar';
 
-import { useTus, TusClientProvider } from '../index';
+import { useTus, TusClientProvider, DefaultOptions } from '../index';
 import { BasicButton } from './components/BasicButton';
-import { TUS_DEMO_ENDPOINT } from './constants';
 import { UploadIcon } from './components/UploadIcon';
 import { LoadingCircle } from './components/LoadingCircle';
+import { TUS_DEMO_ENDPOINT } from './constants';
 
 export default {
   title: 'useTus',
 } as Meta;
 
-export const Basic = () => (
-  <TusClientProvider>
+const defaultOptions: DefaultOptions = (contents) => {
+  const file = contents instanceof File ? contents : undefined;
+
+  return {
+    endpoint: TUS_DEMO_ENDPOINT,
+    chunkSize: file?.size ? file.size / 10 : undefined,
+    metadata: {
+      filename: file?.name || '',
+      filetype: file?.type || '',
+    },
+  };
+};
+
+export const WithDefaultOptions = () => (
+  <TusClientProvider defaultOptions={defaultOptions}>
     <Uploader />
   </TusClientProvider>
 );
@@ -46,12 +59,6 @@ const Uploader = () => {
       }
 
       setUpload(file, {
-        endpoint: TUS_DEMO_ENDPOINT,
-        chunkSize: file.size / 10,
-        metadata: {
-          filename: file.name,
-          filetype: file.type,
-        },
         onProgress: (bytesSent, bytesTotal) => {
           setProgress(Number(((bytesSent / bytesTotal) * 100).toFixed(2)));
         },
@@ -82,7 +89,12 @@ const Uploader = () => {
         <div className="mt-8">
           <UploadIcon />
         </div>
-        <div className="mt-8 flex justify-center items-center flex-col text-sm text-gray-700">
+        <div className="flex flex-col items-center justify-center mt-8 text-sm text-gray-700">
+          <p>
+            Here is a demo with defaultOptions specified for TusClientProvider.
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center mt-8 text-sm text-gray-700">
           <p>
             In this demo, you can upload to the demo-only server provided by tus
             official.

--- a/src/__stories__/constants.ts
+++ b/src/__stories__/constants.ts
@@ -1,5 +1,1 @@
-import { Upload } from 'tus-js-client';
-
-export const defaultOptions: Upload['options'] = {
-  endpoint: 'https://tusd.tusdemo.net/files/',
-};
+export const TUS_DEMO_ENDPOINT = 'https://tusd.tusdemo.net/files/' as const;

--- a/src/__tests__/useTus.test.tsx
+++ b/src/__tests__/useTus.test.tsx
@@ -8,6 +8,7 @@ import { useTusClientDispatch, useTusClientState } from '../core/contexts';
 import { createConsoleErrorMock, insertEnvValue } from './utils/mock';
 import { TusClientState } from '../core/tusClientReducer';
 import * as useTusUtils from '../useTus/utils';
+import { DefaultOptions } from '../core/tusHandler';
 
 /* eslint-disable no-console */
 
@@ -221,10 +222,14 @@ it('Should be reflected onto the TusClientProvider', async () => {
 });
 
 it('Should setUpload without option args', async () => {
+  const defaultOptions: DefaultOptions = () => ({
+    endpoint: 'hoge',
+  });
+
   await act(async () => {
     const { result, waitForNextUpdate } = renderHook(() => useTus(), {
       wrapper: ({ children }) => (
-        <TusClientProvider defaultOptions={{ endpoint: 'hoge' }}>
+        <TusClientProvider defaultOptions={defaultOptions}>
           {children}
         </TusClientProvider>
       ),
@@ -280,6 +285,10 @@ describe('Should not throw even if the TusClientProvider has not found on produc
 });
 
 it('Should set tus config from context value', async () => {
+  const defaultOptions: DefaultOptions = () => ({
+    endpoint: 'hoge',
+  });
+
   await act(async () => {
     const { result, waitForNextUpdate } = renderHook(
       ({ cacheKey }: { cacheKey: string }) => {
@@ -293,7 +302,7 @@ it('Should set tus config from context value', async () => {
         wrapper: ({ children }) => (
           <TusClientProvider
             canStoreURLs={false}
-            defaultOptions={{ endpoint: 'hoge' }}
+            defaultOptions={defaultOptions}
           >
             {children}
           </TusClientProvider>
@@ -311,7 +320,9 @@ it('Should set tus config from context value', async () => {
       actualTus.Upload
     );
     expect(
-      result.current.tusClientState.tusHandler.getTus.defaultOptions.endpoint
+      result.current.tusClientState.tusHandler.getTus.defaultOptions(
+        getBlob('hello')
+      ).endpoint
     ).toBe('hoge');
 
     const file: Upload['file'] = getBlob('hello');

--- a/src/core/tusHandler.ts
+++ b/src/core/tusHandler.ts
@@ -1,18 +1,24 @@
 import * as tus from 'tus-js-client';
+import { Upload } from 'tus-js-client';
 
-export type Tus = typeof tus;
+export type DefaultOptions = (file: Upload['file']) => tus.UploadOptions;
 export type TusConfigs = Partial<{
   canStoreURLs: boolean;
-  defaultOptions: tus.UploadOptions;
+  defaultOptions: DefaultOptions;
 }>;
 
+export type Tus = Readonly<
+  Omit<typeof tus, 'defaultOptions'> & Required<TusConfigs>
+>;
+
+export const initialDefaultOptions: DefaultOptions = () => tus.defaultOptions;
 export class TusHandler {
   private tus: Tus;
 
   constructor(tusConfigs?: TusConfigs) {
     const {
       canStoreURLs = tus.canStoreURLs,
-      defaultOptions = tus.defaultOptions,
+      defaultOptions = initialDefaultOptions,
     } = tusConfigs || {};
 
     this.tus = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './useTus';
 export * from './TusClientProvider';
+export type { DefaultOptions } from './core/tusHandler';
 
 // tus-js-client
 export type {

--- a/src/useTus/useTus.ts
+++ b/src/useTus/useTus.ts
@@ -54,8 +54,9 @@ export const useTus = (useTusOptions?: UseTusOptions): UseTusResult => {
         },
         dispatcher
       );
+
       const uploadOptions: Upload['options'] = {
-        ...tus.defaultOptions,
+        ...tus.defaultOptions?.(file),
         ...options,
         onSuccess,
         onError,

--- a/src/useTus/useTus.ts
+++ b/src/useTus/useTus.ts
@@ -47,17 +47,22 @@ export const useTus = (useTusOptions?: UseTusOptions): UseTusResult => {
         dispatch: tusClientDispatch,
         internalDispatch: setInternalTusState,
       };
+
+      const targetOptions = {
+        ...tus.defaultOptions(file),
+        ...options,
+      };
+
       const { onSuccess, onError } = createOptionHandler(
         {
-          onError: options.onError,
-          onSuccess: options.onSuccess,
+          onError: targetOptions.onError,
+          onSuccess: targetOptions.onSuccess,
         },
         dispatcher
       );
 
       const uploadOptions: Upload['options'] = {
-        ...tus.defaultOptions?.(file),
-        ...options,
+        ...targetOptions,
         onSuccess,
         onError,
       };


### PR DESCRIPTION
## Overview
- Update `defaultOptions` props of `TusClientProvider` to function.
- Add `defaultOptions` stories.

## Why
Previously, the type of `defaultOptions` props is just object.

But It allowed you to intuitively specify default options, but it did not allow you to specify the default options associated with the you want to upload.

For this reason, I changed `defaultOptions` to allow to be specified as follows.

```tsx
const defaultOptions: DefaultOptions = (contents) => {
  const file = contents instanceof File ? contents : undefined;

  return {
    endpoint: 'https://example.com',
    metadata: file
      ? {
          filename: file.name,
          filetype: file.type,
        }
      : undefined,
  };
};

export const App = () => (
  <TusClientProvider defaultOptions={defaultOptions}>
    <Uploader />
  </TusClientProvider>
);
```