### PR TITLE
🐛Fix: TusClientProvider not working with React v18

### DIFF
--- a/src/TusClientProvider/TusClientProvider.tsx
+++ b/src/TusClientProvider/TusClientProvider.tsx
@@ -13,6 +13,7 @@ import {
 import { ERROR_MESSAGES } from "./constants";
 
 export type TusClientProviderProps = Readonly<{
+  children?: React.ReactNode;
   defaultOptions?: DefaultOptions;
 }>;
 


### PR DESCRIPTION
Motivation:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/105971119/169664900-d96d3864-af54-4975-8569-d82ab0863548.png">

Solution:
- Adding children property explicitly to TusClientProviderProps.
