### PR TITLE
Remove some types exported from 'tus-js-client'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,3 @@ export * from "./useTusClient";
 export * from "./TusClientProvider";
 
 export type { TusHooksResult, TusHooksOptions } from "./types";
-
-// tus-js-client
-export type {
-  Upload,
-  UploadOptions,
-  UrlStorage,
-  PreviousUpload,
-  FileReader,
-  FileSource,
-  SliceResult,
-  HttpStack,
-  HttpRequest,
-  HttpResponse,
-} from "tus-js-client";


### PR DESCRIPTION
## Overview
This PR will remove some types exported from 'tus-js-client' because 'tus-js-client' has been already defined as peerDependencies