### PR TITLE
Fix to pass arguments for `start` and `abort` function

### DIFF
--- a/src/__tests__/useTus.test.tsx
+++ b/src/__tests__/useTus.test.tsx
@@ -232,6 +232,19 @@ describe("useTus", () => {
     expect(consoleErrorMock).toHaveBeenCalledWith();
   });
 
+  it("Should pass `shouldTerminate`", () => {
+    const { result } = renderUseTus();
+    act(() => {
+      result.current.setUpload(getBlob("hello"), getDefaultOptions());
+    });
+
+    result.current.upload?.abort(true);
+    expect(abort).toHaveBeenCalledWith(true);
+
+    result.current.upload?.abort(false);
+    expect(abort).toHaveBeenCalledWith(false);
+  });
+
   describe("Options", () => {
     describe("autoAbort", () => {
       it("Should abort on unmount", async () => {

--- a/src/__tests__/useTusStore.test.tsx
+++ b/src/__tests__/useTusStore.test.tsx
@@ -365,6 +365,20 @@ describe("useTusStore", () => {
     expect(consoleErrorMock).toHaveBeenCalledWith();
   });
 
+  it("Should pass `shouldTerminate`", () => {
+    const { result } = renderUseTusStore({ options: { Upload } });
+
+    act(() => {
+      result.current.tus.setUpload(getBlob("hello"), getDefaultOptions());
+    });
+
+    result.current.tus.upload?.abort(true);
+    expect(abort).toHaveBeenCalledWith(true);
+
+    result.current.tus.upload?.abort(false);
+    expect(abort).toHaveBeenCalledWith(false);
+  });
+
   describe("Options", () => {
     describe("autoAbort", () => {
       it("Should abort on unmount", async () => {

--- a/src/utils/core/createUpload.ts
+++ b/src/utils/core/createUpload.ts
@@ -48,13 +48,13 @@ export const createUpload = ({
   const originalStart = upload.start.bind(upload);
   const originalAbort = upload.abort.bind(upload);
 
-  const start = () => {
-    originalStart();
+  const start: UploadType["start"] = (...args) => {
+    originalStart(...args);
     onStart();
   };
 
-  const abort = async () => {
-    originalAbort();
+  const abort: UploadType["abort"] = async (...args) => {
+    originalAbort(...args);
     onAbort();
   };
 


### PR DESCRIPTION
## Overview
This PR addresses the issue where the shouldTerminate argument was not being passed to the abort function in the use-tus library that is requested in #51 

With this fix, calling the abort function with the shouldTerminate argument will work as expected.
