### PR TITLE
Enable NPM provenance for package attestation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,6 +47,8 @@ jobs:
   publish-npm:
     needs: [test, check-version]
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_PROVENANCE: true
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
This PR adds the NPM_CONFIG_PROVENANCE environment variable to the npm-publish workflow. 

By enabling NPM Provenance, packages published through GitHub Actions will include attestation metadata that proves where and how the package was built. This enhancement improves supply chain security by allowing package consumers to verify that the published package was indeed built by the official GitHub Actions workflow, providing greater transparency and trust in the distribution process.