### PR TITLE
Narrow the `tus-js-client` peerDependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-tus",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "React hooks for resumable file uploads using tus-js-client",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
     "react": ">=16.8",
     "tus-js-client": ">=2.2.0 <4.2.0"
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "tus-js-client": ">=2.2.0"
+    "tus-js-client": ">=2.2.0 <4.2.0"
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
 }


### PR DESCRIPTION
Starting from v4.2.1, `tus-js-client` changed the `onSuccess` callback type from `(() => void) | null` to
  `((payload: OnSuccessPayload) => void) | null`. Because `use-tus` derives `TusHooksUploadFnOptions` dynamically
  from `UploadOptions`, this type change propagates and causes TypeScript compilation errors in the following
  locations:

  - `useTus.ts`: `targetOptions?.onSuccess?.(upload)` — passes `Upload` where `OnSuccessPayload` is now expected
  - `useTusStore.ts`: same issue

  The upper bound `<4.2.0` reflects the last version where both the type definitions and the internal
  implementation are compatible.

  Note: v4.2.0 changed the runtime behavior of `onSuccess` (introducing the `payload` argument) but did not update
   the type definition until v4.2.1. The boundary is set at `<4.2.0` since that is when the semantic API change
  was introduced.
