### PR TITLE
Migrate npm publish to OIDC connector and add workflow_dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
       - main
     tags:
       - "!*"
+  workflow_dispatch:
 
 jobs:
   check-version:
@@ -24,8 +25,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - run: pnpm add can-npm-publish
       - run: npx can-npm-publish --verbose
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
   test:
     runs-on: ubuntu-latest
     steps:
@@ -68,5 +67,3 @@ jobs:
         run: pnpm install --frozen-lockfile
       - run: pnpm install --frozen-lockfile
       - run: pnpm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}


### PR DESCRIPTION
## Summary
  - Remove `NPM_PUBLISH_TOKEN` secret dependency by switching to npm's OIDC connector (Trusted Publishing)
  - Add `workflow_dispatch` trigger to allow manual publish runs from the GitHub Actions UI