### PR TITLE
Upgrade tus-js-client to v4.3.1 and fix onSuccess compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "tus-js-client": ">=2.2.0 <4.2.0"
+    "tus-js-client": ">=2.2.0 <5.0.0"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "storybook": "^7.5.1",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
     "ts-jest": "^29.1.1",
-    "tus-js-client": "4.0.0",
+    "tus-js-client": "4.3.1",
     "typescript": "^5.2.2",
     "vite": "^4.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^29.1.1
         version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.3.0))(typescript@5.9.2)
       tus-js-client:
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 4.3.1
+        version: 4.3.1
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
@@ -5619,8 +5619,8 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  tus-js-client@4.0.0:
-    resolution: {integrity: sha512-ZGyu/QCx6RXgWBywk1+c6VONPmEQ9GNrkn8j/+lntdaqZu6p4JCfjKxXWYJFx0CZRhKvhOyk6qT4/WVvb/bBmw==}
+  tus-js-client@4.3.1:
+    resolution: {integrity: sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==}
     engines: {node: '>=18'}
 
   type-check@0.4.0:
@@ -12702,7 +12702,7 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.9.2
 
-  tus-js-client@4.0.0:
+  tus-js-client@4.3.1:
     dependencies:
       buffer-from: 1.1.2
       combine-errors: 3.0.3

--- a/src/__tests__/createUpload.test.ts
+++ b/src/__tests__/createUpload.test.ts
@@ -74,8 +74,9 @@ describe("createUpload", () => {
     expect(uploadFnOptions.onBeforeRequest).not.toBeCalled();
     expect(uploadFnOptions.onChunkComplete).not.toBeCalled();
 
-    upload.options?.onSuccess?.();
-    expect(uploadFnOptions.onSuccess).toBeCalledWith(upload);
+    const payload = { lastResponse: createMock<HttpResponse>() };
+    upload.options?.onSuccess?.(payload);
+    expect(uploadFnOptions.onSuccess).toBeCalledWith(payload, upload);
 
     upload.options?.onError?.(detailedError);
     expect(uploadFnOptions.onError).toBeCalledWith(detailedError, upload);

--- a/src/__tests__/useTus.test.tsx
+++ b/src/__tests__/useTus.test.tsx
@@ -173,6 +173,35 @@ describe("useTus", () => {
       });
       expect(consoleErrorMock).toHaveBeenCalledWith();
     });
+
+    it("Should pass payload and upload to the onSuccess callback", async () => {
+      const { result } = renderUseTus({ autoStart: false });
+
+      const onSuccessMock = jest.fn();
+      act(() => {
+        result.current.setUpload(getBlob("hello"), {
+          ...getDefaultOptions(),
+          onSuccess: onSuccessMock,
+        });
+      });
+
+      await waitFor(() => result.current.upload);
+      const upload = result.current.upload;
+
+      const onSuccess = upload?.options?.onSuccess;
+      if (!onSuccess) {
+        throw new Error("onSuccess is falsly.");
+      }
+
+      const mockResponse = createMock<HttpResponse>();
+      const payload = { lastResponse: mockResponse };
+
+      act(() => {
+        onSuccess(payload);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalledWith(payload, upload);
+    });
   });
 
   it("Should change error state on error", async () => {

--- a/src/__tests__/useTus.test.tsx
+++ b/src/__tests__/useTus.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useRef } from "react";
+import { HttpResponse } from "tus-js-client";
 import { TusHooksOptions, useTus } from "../index";
 import { getBlob } from "./utils/getBlob";
 import {
@@ -7,6 +8,7 @@ import {
   createUploadMock,
   startOrResumeUploadMock,
 } from "./utils/mock";
+import { createMock } from "./utils/createMock";
 import { getDefaultOptions } from "./utils/getDefaultOptions";
 import { UploadFile } from "../types";
 
@@ -157,7 +159,7 @@ describe("useTus", () => {
       }
 
       act(() => {
-        onSuccess();
+        onSuccess({ lastResponse: createMock<HttpResponse>() });
       });
 
       expect(result.current).toEqual({

--- a/src/__tests__/useTusStore.test.tsx
+++ b/src/__tests__/useTusStore.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { HttpResponse } from "tus-js-client";
 import {
   TusClientProvider,
   TusClientProviderProps,
@@ -16,6 +17,7 @@ import {
   startOrResumeUploadMock,
   createUploadMock,
 } from "./utils/mock";
+import { createMock } from "./utils/createMock";
 import { ERROR_MESSAGES } from "../TusClientProvider/constants";
 import { UploadFile } from "../types";
 
@@ -295,7 +297,7 @@ describe("useTusStore", () => {
     }
 
     act(() => {
-      onSuccess();
+      onSuccess({ lastResponse: createMock<HttpResponse>() });
     });
 
     expect(result.current.tus).toEqual({

--- a/src/__tests__/useTusStore.test.tsx
+++ b/src/__tests__/useTusStore.test.tsx
@@ -312,6 +312,35 @@ describe("useTusStore", () => {
     expect(consoleErrorMock).toHaveBeenCalledWith();
   });
 
+  it("Should pass payload and upload to the onSuccess callback", async () => {
+    const { result } = renderUseTusStore({ options: { Upload } });
+
+    const onSuccessMock = jest.fn();
+    act(() => {
+      result.current.tus.setUpload(getBlob("hello"), {
+        ...getDefaultOptions(),
+        onSuccess: onSuccessMock,
+      });
+    });
+
+    await waitFor(() => result.current.tus.upload);
+    const upload = result.current.tus.upload;
+
+    const onSuccess = upload?.options?.onSuccess;
+    if (!onSuccess) {
+      throw new Error("onSuccess is falsly.");
+    }
+
+    const mockResponse = createMock<HttpResponse>();
+    const payload = { lastResponse: mockResponse };
+
+    act(() => {
+      onSuccess(payload);
+    });
+
+    expect(onSuccessMock).toHaveBeenCalledWith(payload, upload);
+  });
+
   it("Should change error state on error", async () => {
     const { result } = renderUseTusStore({ options: { Upload } });
     expect(result.current.tus).toEqual({

--- a/src/useTus/useTus.ts
+++ b/src/useTus/useTus.ts
@@ -5,6 +5,7 @@ import {
   TusHooksResult,
   TusTruthlyContext,
   TusContext,
+  TusHooksUploadFnOptions,
   TusHooksUploadOptions,
 } from "../types";
 import {
@@ -60,11 +61,11 @@ export const useTus = (baseOption: TusHooksOptions = {}): TusHooksResult => {
         ...options,
       };
 
-      function onSuccess() {
+      const onSuccess: TusHooksUploadFnOptions["onSuccess"] = (...args) => {
         updateTusTruthlyContext({ isSuccess: true, isUploading: false });
 
-        targetOptions?.onSuccess?.(upload);
-      }
+        targetOptions?.onSuccess?.(...args);
+      };
 
       const onError = (error: Error) => {
         updateTusTruthlyContext({

--- a/src/useTusStore/useTusStore.ts
+++ b/src/useTusStore/useTusStore.ts
@@ -12,6 +12,7 @@ import {
 import {
   TusHooksOptions,
   TusHooksResult,
+  TusHooksUploadFnOptions,
   TusHooksUploadOptions,
 } from "../types";
 import {
@@ -43,11 +44,11 @@ export const useTusStore = (
         ...options,
       };
 
-      const onSuccess = () => {
+      const onSuccess: TusHooksUploadFnOptions["onSuccess"] = (...args) => {
         tusClientDispatch(
           updateUploadContext(cacheKey, { isSuccess: true, isUploading: false })
         );
-        targetOptions?.onSuccess?.(upload);
+        targetOptions?.onSuccess?.(...args);
       };
 
       const onError = (error: Error) => {


### PR DESCRIPTION
## Overview
`tus-js-client` v4.2.0 changed the runtime behavior of the `onSuccess` callback from
  `() => void` to `(payload: OnSuccessPayload) => void` where `OnSuccessPayload = { lastResponse: HttpResponse }`.
  The type definition was updated in v4.2.1.

  Because `use-tus` derives `TusHooksUploadFnOptions` from `UploadOptions` via mapped types,
  this change propagated and caused the internal `onSuccess` wrappers in `useTus.ts` and
  `useTusStore.ts` to silently drop the payload when forwarding to the user's callback.
